### PR TITLE
New screening times

### DIFF
--- a/kinogoteborg/src/app/api/booking/[id]/times/route.js
+++ b/kinogoteborg/src/app/api/booking/[id]/times/route.js
@@ -9,7 +9,11 @@ export async function GET(req, { params }) {
   const date = url.searchParams.get("date");
   const dateObj = new Date(date);
 
-  //to match -2 hours in database
+  //To match -2 hours in database to get a full day
+  //due to the case of manually filling database
+  //with +2 hours using Postman.
+  //When database is correct startOfDate & endOfDate can
+  //be updated with (0, 0, 0, 0) respectively (23, 59, 59, 999).
   const startOfDate = new Date(dateObj.setHours(2, 0, 0, 0));
   const endOfDate = new Date(startOfDate);
   endOfDate.setDate(endOfDate.getDate() + 1);
@@ -20,6 +24,7 @@ export async function GET(req, { params }) {
   }
 
   await connectToDb();
+
   try {
     const screenings = await Screening.find({
       "attributes.movieID": id,

--- a/kinogoteborg/src/app/api/booking/[id]/times/route.js
+++ b/kinogoteborg/src/app/api/booking/[id]/times/route.js
@@ -1,0 +1,37 @@
+import connectToDb from "@/lib/connectToDb";
+import Screening from "@/models/screeningsModel";
+import { NextResponse } from "next/server";
+
+export async function GET(req, { params }) {
+  const id = params.id;
+
+  const url = new URL(req.url);
+  const date = url.searchParams.get("date");
+  const dateObj = new Date(date);
+
+  //to match -2 hours in database
+  const startOfDate = new Date(dateObj.setHours(2, 0, 0, 0));
+  const endOfDate = new Date(startOfDate);
+  endOfDate.setDate(endOfDate.getDate() + 1);
+  endOfDate.setHours(1, 59, 59, 999);
+
+  if (!date) {
+    return NextResponse.json({ success: "false", error: "Date is missing" });
+  }
+
+  await connectToDb();
+  try {
+    const screenings = await Screening.find({
+      "attributes.movieID": id,
+      "attributes.date": {
+        $gte: startOfDate,
+        $lte: endOfDate,
+      },
+    });
+
+    return NextResponse.json({ success: "true", data: screenings });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ success: "false", error: error.message });
+  }
+}

--- a/kinogoteborg/src/app/booking/[movieID]/page.jsx
+++ b/kinogoteborg/src/app/booking/[movieID]/page.jsx
@@ -9,7 +9,8 @@ import BookingModal from "@/app/components/booking/bookingModal";
 import { postSeats, putSeats } from "@/scripts/fetchSeatsToBook";
 import { NoSeats } from "@/app/components/booking/NoSeats";
 import MovieDetails from "@/app/components/booking/movieDetails";
-import ScreeningDates from "@/app/components/booking/screeningDates";
+import ScreeningDates from "@/app/components/booking/screeningDates"; 
+import ScreeningTimes from "@/app/components/booking/screeningTimes";
 
 const Modal = ({
   isModalOpen,
@@ -104,7 +105,9 @@ export default function Page({ params }) {
           <ScreeningDates id={id} setSelectedDate={setSelectedDate} selectedDate={selectedDate} />
         </div>
 
-        <div className="md:col-span-2 md:col-start-1 md:row-start-2 flex flex-row align-center justify-evenly p-2 border"></div>
+        <div className="md:col-span-2 md:col-start-1 md:row-start-2 flex flex-row align-center justify-evenly p-2 border">
+        <ScreeningTimes id={id} setSelectedTime={setSelectedTime} selectedTime={selectedTime} selectedDate={selectedDate} />
+        </div>
         <div className="md:col-start-3 md:row-start-2 border">amount of guests</div>
         <div className="flex flex-col md:col-span-3 md:row-span-6 md:col-start-1 md:row-start-3 border items-center m-0">
           <div id="movieScreen" className="h-2 w-full bg-black col-start-1 rounded-md border"></div>

--- a/kinogoteborg/src/app/components/booking/screeningDates.jsx
+++ b/kinogoteborg/src/app/components/booking/screeningDates.jsx
@@ -26,7 +26,7 @@ export default function ScreeningDates({ id, setSelectedDate, selectedDate }) {
           }
         });
 
-        //to sort screening dates in decending order
+        //to sort screening dates in ascending order
         const sortedScreeningDates = Array.from(screeningDays).sort((a, b) => {
           const [dayA] = a.split(" ");
           const [dayB] = b.split(" ");

--- a/kinogoteborg/src/app/components/booking/screeningDates.jsx
+++ b/kinogoteborg/src/app/components/booking/screeningDates.jsx
@@ -1,22 +1,29 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { fetchScreeningDates } from "@/scripts/fetchScreeningDates";
 
 export default function ScreeningDates({ id, setSelectedDate, selectedDate }) {
   const [screeningDates, setScreeningDates] = useState([]);
 
   useEffect(() => {
-    fetch(`http://localhost:3000/api/booking/${id}/dates`)
-      .then((res) => res.json())
-      .then((data) => {
+    const fetchedDataForDates = async () => {
+      const fetchedData = await fetchScreeningDates(id);
+
+      if (fetchedData.length === 0) {
+        const noScreeningDates = ["No available dates"];
+
+        setScreeningDates(noScreeningDates);
+        setSelectedDate(noScreeningDates[0]);
+      } else {
         //to create Month name to later render
         //one screening date per day, for example "19 June"
         const todaysDate = new Date();
         const todaysMonth = todaysDate.getMonth() + 1;
         const todaysYear = todaysDate.getFullYear();
-
         const screeningDays = new Set();
-        data.data.forEach((screening) => {
+
+        fetchedData.forEach((screening) => {
           const date = new Date(screening.attributes.date);
           const day = date.getDate();
           const month = date.getMonth() + 1;
@@ -35,7 +42,10 @@ export default function ScreeningDates({ id, setSelectedDate, selectedDate }) {
 
         setScreeningDates(sortedScreeningDates);
         setSelectedDate(sortedScreeningDates[0]);
-      });
+      }
+    };
+
+    fetchedDataForDates();
   }, [id]);
 
   const handleDateClick = (date) => {

--- a/kinogoteborg/src/app/components/booking/screeningDates.jsx
+++ b/kinogoteborg/src/app/components/booking/screeningDates.jsx
@@ -48,7 +48,7 @@ export default function ScreeningDates({ id, setSelectedDate, selectedDate }) {
         <div
           key={index}
           onClick={() => handleDateClick(date)}
-          className={`flex items-center justify-center w-[8vw] h-[4vw] p-2 rounded text-center hover:bg-red-700 text-stone-300 font-bold cursor-pointer 
+          className={`flex items-center justify-center min-w-[8vw] min-h-[4vw] p-2 rounded text-center hover:bg-red-700 text-stone-300 font-bold cursor-pointer 
                     ${date === selectedDate ? "bg-red-900 text-white font-bold" : "bg-gray-500 text-white"} mb-2 md:mb-0 mx-1`}
         >
           {date}

--- a/kinogoteborg/src/app/components/booking/screeningTimes.jsx
+++ b/kinogoteborg/src/app/components/booking/screeningTimes.jsx
@@ -9,19 +9,26 @@ export default function ScreeningTimes({ id, setSelectedTime, selectedTime, sele
   useEffect(() => {
     const fetchedDataForTimes = async () => {
       const fetchedData = await fetchScreeningTimes(id, selectedDate);
-      const screeningStartTimes = fetchedData.map((data) =>
-        data.attributes.startTime.slice(12, 16)
-      );
 
-      //to sort screening times in decending order
-      const sortedScreeningTimes = Array.from(screeningStartTimes).sort((a, b) => {
-        const [timeA] = a.split(" ");
-        const [timeB] = b.split(" ");
-        return Number(timeA) - Number(timeB);
-      });
+      if (fetchedData.length === 0) {
+        const noScreeningTimes = ["No available times"];
+        setScreeningTimes(noScreeningTimes);
+        setSelectedTime(noScreeningTimes[0]);
+      } else {
+        const screeningStartTimes = fetchedData.map((data) =>
+          data.attributes.startTime.slice(11, 16)
+        );
 
-      setScreeningTimes(sortedScreeningTimes);
-      setSelectedTime(sortedScreeningTimes[0]);
+        //to sort screening times in ascending order
+        const sortedScreeningTimes = Array.from(screeningStartTimes).sort((a, b) => {
+          const [timeA] = a.split(" ");
+          const [timeB] = b.split(" ");
+          return Number(timeA) - Number(timeB);
+        });
+
+        setScreeningTimes(sortedScreeningTimes);
+        setSelectedTime(sortedScreeningTimes[0]);
+      }
     };
 
     fetchedDataForTimes();

--- a/kinogoteborg/src/app/components/booking/screeningTimes.jsx
+++ b/kinogoteborg/src/app/components/booking/screeningTimes.jsx
@@ -12,6 +12,7 @@ export default function ScreeningTimes({ id, setSelectedTime, selectedTime, sele
 
       if (fetchedData.length === 0) {
         const noScreeningTimes = ["No available times"];
+
         setScreeningTimes(noScreeningTimes);
         setSelectedTime(noScreeningTimes[0]);
       } else {

--- a/kinogoteborg/src/app/components/booking/screeningTimes.jsx
+++ b/kinogoteborg/src/app/components/booking/screeningTimes.jsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { fetchScreeningTimes } from "@/scripts/fetchScreeningTimes";
+
+export default function ScreeningTimes({ id, setSelectedTime, selectedTime, selectedDate }) {
+  const [screeningTimes, setScreeningTimes] = useState([]);
+  console.log(selectedDate);
+
+  useEffect(() => {
+    const fetchedDataForTimes = async () => {
+      const fetchedData = await fetchScreeningTimes(id, selectedDate);
+      setScreeningTimes(fetchedData.data);
+      setSelectedTime(fetchedData.data[0]);
+    };
+
+    fetchedDataForTimes();
+  }, [selectedDate]);
+
+  const handleTimeClick = (time) => {
+    setSelectedTime(time);
+  };
+
+  return (
+    <div className="flex flex-wrap justify-center my-auto">
+      {screeningTimes.map((time, index) => (
+        <div
+          key={index}
+          onClick={() => handleTimeClick(time)}
+          className={`flex items-center justify-center w-[8vw] h-[4vw] p-2 rounded text-center hover:bg-red-700 text-stone-300 font-bold cursor-pointer 
+                    ${time === selectedTime ? "bg-red-900 text-white font-bold" : "bg-gray-500 text-white"} mb-2 md:mb-0 mx-1`}
+        >
+          {time}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/kinogoteborg/src/app/components/booking/screeningTimes.jsx
+++ b/kinogoteborg/src/app/components/booking/screeningTimes.jsx
@@ -5,13 +5,23 @@ import { fetchScreeningTimes } from "@/scripts/fetchScreeningTimes";
 
 export default function ScreeningTimes({ id, setSelectedTime, selectedTime, selectedDate }) {
   const [screeningTimes, setScreeningTimes] = useState([]);
-  console.log(selectedDate);
 
   useEffect(() => {
     const fetchedDataForTimes = async () => {
       const fetchedData = await fetchScreeningTimes(id, selectedDate);
-      setScreeningTimes(fetchedData.data);
-      setSelectedTime(fetchedData.data[0]);
+      const screeningStartTimes = fetchedData.map((data) =>
+        data.attributes.startTime.slice(12, 16)
+      );
+
+      //to sort screening times in decending order
+      const sortedScreeningTimes = Array.from(screeningStartTimes).sort((a, b) => {
+        const [timeA] = a.split(" ");
+        const [timeB] = b.split(" ");
+        return Number(timeA) - Number(timeB);
+      });
+
+      setScreeningTimes(sortedScreeningTimes);
+      setSelectedTime(sortedScreeningTimes[0]);
     };
 
     fetchedDataForTimes();

--- a/kinogoteborg/src/app/components/booking/screeningTimes.jsx
+++ b/kinogoteborg/src/app/components/booking/screeningTimes.jsx
@@ -44,7 +44,7 @@ export default function ScreeningTimes({ id, setSelectedTime, selectedTime, sele
         <div
           key={index}
           onClick={() => handleTimeClick(time)}
-          className={`flex items-center justify-center w-[8vw] h-[4vw] p-2 rounded text-center hover:bg-red-700 text-stone-300 font-bold cursor-pointer 
+          className={`flex items-center justify-center min-w-[8vw] min-h-[4vw] p-2 rounded text-center hover:bg-red-700 text-stone-300 font-bold cursor-pointer 
                     ${time === selectedTime ? "bg-red-900 text-white font-bold" : "bg-gray-500 text-white"} mb-2 md:mb-0 mx-1`}
         >
           {time}

--- a/kinogoteborg/src/scripts/fetchScreeningDates.jsx
+++ b/kinogoteborg/src/scripts/fetchScreeningDates.jsx
@@ -1,0 +1,19 @@
+export async function fetchScreeningDates(id) {
+  if (!id) {
+    return [];
+  }
+
+  try {
+    const res = await fetch(`http://localhost:3000/api/booking/${id}/dates`);
+
+    if (!res.ok) {
+      throw new Error("Network response was not ok");
+    }
+
+    const data = await res.json();
+    return data.data;
+  } catch (error) {
+    console.error("Error when fetch dates", error);
+    return [];
+  }
+}

--- a/kinogoteborg/src/scripts/fetchScreeningTimes.jsx
+++ b/kinogoteborg/src/scripts/fetchScreeningTimes.jsx
@@ -1,0 +1,36 @@
+export async function fetchScreeningTimes(id, date) {
+  const formattedDate = createDateIndex(date);
+
+  return fetch(`http://localhost:3000/api/booking/${id}/times/?date=${formattedDate}`)
+    .then((res) => {
+      if (!res.ok) {
+        throw new Error("Network response was not ok");
+      }
+      return res.json();
+    })
+    .catch((error) => {
+      throw error;
+    });
+}
+
+function createDateIndex(dateMonthName) {
+  const monthParts = dateMonthName.split(" ");
+  const monthIndex = {
+    Jan: "01",
+    Feb: "02",
+    Mar: "03",
+    Apr: "04",
+    May: "05",
+    Jun: "06",
+    Jul: "07",
+    Aug: "08",
+    Sep: "09",
+    Oct: "10",
+    Nov: "11",
+    Dec: "12",
+  };
+  const year = new Date().getFullYear();
+  const month = monthIndex[monthParts[1]];
+  const day = monthParts[0];
+  return `${year}-${month}-${day}`;
+}

--- a/kinogoteborg/src/scripts/fetchScreeningTimes.jsx
+++ b/kinogoteborg/src/scripts/fetchScreeningTimes.jsx
@@ -17,7 +17,7 @@ export async function fetchScreeningTimes(id, date) {
     const data = await resp.json();
     return data.data;
   } catch (error) {
-    console.error("Error when fetch", error);
+    console.error("Error when fetch times", error);
     return [];
   }
 }

--- a/kinogoteborg/src/scripts/fetchScreeningTimes.jsx
+++ b/kinogoteborg/src/scripts/fetchScreeningTimes.jsx
@@ -1,23 +1,24 @@
 export async function fetchScreeningTimes(id, date) {
+  if (!date) {
+    return [];
+  }
+
   const formattedDate = createDateIndex(date);
 
-  const resp = await fetch(`http://localhost:3000/api/booking/${id}/times/?date=${formattedDate}`);
-  const data = await resp.json();
+  try {
+    const resp = await fetch(
+      `http://localhost:3000/api/booking/${id}/times/?date=${formattedDate}`
+    );
 
-  return data.data;
+    if (!resp.ok) {
+      throw new Error("Network response was not ok");
+    }
 
-  {
-    /*return fetch(`http://localhost:3000/api/booking/${id}/times/?date=${formattedDate}`)
-    .then((res) => {
-      if (!res.ok) {
-        throw new Error("Network response was not ok");
-      }
-      console.log(res.json());
-      return res.json();
-    })
-    .catch((error) => {
-      throw error;
-    });*/
+    const data = await resp.json();
+    return data.data;
+  } catch (error) {
+    console.error("Error when fetch", error);
+    return [];
   }
 }
 

--- a/kinogoteborg/src/scripts/fetchScreeningTimes.jsx
+++ b/kinogoteborg/src/scripts/fetchScreeningTimes.jsx
@@ -1,16 +1,24 @@
 export async function fetchScreeningTimes(id, date) {
   const formattedDate = createDateIndex(date);
 
-  return fetch(`http://localhost:3000/api/booking/${id}/times/?date=${formattedDate}`)
+  const resp = await fetch(`http://localhost:3000/api/booking/${id}/times/?date=${formattedDate}`);
+  const data = await resp.json();
+
+  return data.data;
+
+  {
+    /*return fetch(`http://localhost:3000/api/booking/${id}/times/?date=${formattedDate}`)
     .then((res) => {
       if (!res.ok) {
         throw new Error("Network response was not ok");
       }
+      console.log(res.json());
       return res.json();
     })
     .catch((error) => {
       throw error;
-    });
+    });*/
+  }
 }
 
 function createDateIndex(dateMonthName) {


### PR DESCRIPTION
Route, component & script for screening times & updated page.jsx. 
The first screening time is automatically chosen when page load. 
If no available times exists a user message like "No available times" is shown instead. 
To handle the fact that times are dependent of dates there is a wrapped async await fetch for screening times. 
To handle error and user message also for dates that component is updated in the same way. 
This also keep a consistent approach how to structure the code like the rest of the project's booking part. 

The database for screenings has been filled with screenings of +2 hours. Therefore the time needs to be adjusted in the route for getting times. There is a comment of this in the route. 

The responsiveness for the red boxes containing dates, times & associated error messages are adjusted to fit the text. 

The database is at the moment filled with screenings until 2024-05-24 for the first 10 movies. 

Some functions might be mooved from both time and date component into scripts, like for example the sorting in ascending order. On the other hand there is not much code in each component and some specific code for these components. The overall readability and understanding of the code might be better if the code is not moved to separate script-files. 

Prettier has been used and also a commit hook. 

![image](https://github.com/Kookiie88/B7_Inlamning_4a/assets/145021772/9b731bad-7130-4a2f-becd-1adcf684a4c6)
![image](https://github.com/Kookiie88/B7_Inlamning_4a/assets/145021772/7e50091b-f530-43f8-b4ce-e0b70bd567bb)
